### PR TITLE
Check for java's existence

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -5,10 +5,15 @@ var INTERVAL = 1500;
 var attempts = 1;
 
 function doInstall () {
-  var setupSelendroid, asyncify;
+  var setupSelendroid;
+  var asyncify = require('asyncbox').asyncify;
+
+  // selendroid needs Java. Fail early if it doesn't exist
+  var androidHelpers = require('appium-android-driver').androidHelpers;
+  asyncify(androidHelpers.getJavaVersion);
+
   try {
     setupSelendroid = require('appium-selendroid-installer').setupSelendroid;
-    asyncify = require('asyncbox').asyncify;
     // TODO: add --conditional flag for npm install so we don't crash if the build
     // dir doesn't exist
     asyncify(setupSelendroid);


### PR DESCRIPTION
On install, fail if the user does not have Java installed. Otherwise we get a cryptic `ENOENT` error when trying to run java later in the install.