### PR TITLE
Clean up logging of install

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var MAX_ATTEMPTS = 20;
+var MAX_ATTEMPTS = 200;
 var INTERVAL = 1500;
 var attempts = 1;
 
@@ -20,7 +20,9 @@ function doInstall () {
   } catch (err) {
     if (attempts > MAX_ATTEMPTS) {
       console.log("Tried too many times to install selendroid, failing");
-      throw err;
+      console.log("Original error: " + err.message);
+      console.log("Please re-run `install appium-selendroid-installer` manually.");
+      throw new Error("Unable to import and run `appium-selendroid-installer`");
     }
     attempts++;
     console.log("Selendroid setup files did not yet exist, waiting...");


### PR DESCRIPTION
Clean up the logging of the timeout condition, otherwise we get cryptic error messages like "fn must be a function" coming from the underlying systems.