### PR TITLE
Fix network connection handling

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import log from './logger';
 import utf7 from 'utf7';
 import { webviewHelpers, CHROMIUM_WIN } from 'appium-android-driver';
+import { DEVICE_PORT } from './driver';
 
 const {imap} = utf7;
 
@@ -107,6 +108,15 @@ helpers.switchContext = async function (name) {
 
 helpers.isChromedriverContext = function (windowName) {
   return windowName === CHROMIUM_WIN;
+};
+
+// Need to override android-driver's version of this since we don't actually
+// have a bootstrap; instead we just restart adb and re-forward the Selendroid
+// port
+helpers.wrapBootstrapDisconnect = async function (wrapped) {
+  await wrapped();
+  await this.adb.restart();
+  await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -166,6 +166,7 @@ class SelendroidDriver extends BaseDriver {
   }
 
   async initAUT () {
+    logger.debug('Initializing application under test');
     // set the localized strings for the current language from the apk
     // TODO: incorporate changes from appium#5308 which fix a race cond-
     // ition bug in old appium and need to be replicated here
@@ -177,12 +178,11 @@ class SelendroidDriver extends BaseDriver {
     if (!this.opts.noSign) {
       let signed = await this.adb.checkApkCert(this.opts.app, this.opts.appPackage);
       if (!signed) {
+        logger.debug('Application not signed. Signing.');
         await this.adb.sign(this.opts.app, this.opts.appPackage);
       }
     }
-    await helpers.installApkRemotely(this.adb, this.opts.app,
-                                     this.opts.appPackage,
-                                     this.opts.fastReset);
+    await helpers.installApkRemotely(this.adb, this.opts);
     // get Selendroid on the device too
     await this.selendroid.installModifiedServer();
   }
@@ -247,15 +247,6 @@ class SelendroidDriver extends BaseDriver {
     return `${WEBVIEW_BASE}0`;
   }
 
-  // Need to override android-driver's version of this since we don't actually
-  // have a bootstrap; instead we just restart adb and re-forward the Selendroid
-  // port
-  async wrapBootstrapDisconnect (wrapped) {
-    await wrapped();
-    await this.adb.restart();
-    await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);
-  }
-
   proxyActive (sessionId) {
     super.proxyActive(sessionId);
 
@@ -290,4 +281,5 @@ for (let [cmd, fn] of _.pairs(commands)) {
   SelendroidDriver.prototype[cmd] = fn;
 }
 
+export { SelendroidDriver, DEVICE_PORT };
 export default SelendroidDriver;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "appium-adb": "^2.5.1",
-    "appium-android-driver": "^1.8.0",
+    "appium-android-driver": "^1.10.16",
     "appium-base-driver": "^2.0.1",
     "appium-logger": "^2.1.0",
     "appium-selendroid-installer": "^0.2.0",

--- a/test/functional/command-e2e-specs.js
+++ b/test/functional/command-e2e-specs.js
@@ -1,0 +1,52 @@
+// transpile:mocha
+
+import path from 'path';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import wd from 'wd';
+import { startServer } from '../..';
+
+
+const TEST_PORT = 4884;
+const TEST_HOST = 'localhost';
+const TEST_APP = path.resolve(__dirname, '..', '..', '..', 'test', 'fixtures',
+                              'selendroid-test-app.apk');
+
+const shouldStartServer = process.env.USE_RUNNING_SERVER !== "0";
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('SelendroidDriver', () => {
+  let server = null;
+
+  before(async () => {
+    if (shouldStartServer) {
+      server = await startServer(TEST_PORT, TEST_HOST);
+    }
+  });
+  after(async () => {
+    if (server) {
+      server.close();
+    }
+  });
+
+  describe('set network connection', () => {
+    // setting network connection uses android-driver methods that call
+    const caps = {
+      platformName: 'Android',
+      deviceName: 'Android Emulator',
+      app: TEST_APP
+    };
+
+    it('should start a session', async () => {
+      let driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      await driver.init(caps);
+
+      let nc = await driver.setNetworkConnection(4);
+      nc.should.eql(4);
+
+      await driver.quit();
+    });
+  });
+});


### PR DESCRIPTION
We were not overriding the `wrapBootstrapDisconnect` function with that of `appium-android-driver`, so it would fail with no bootstrap.

Fixes https://github.com/appium/appium/issues/6658