### PR TITLE
Implement reboot option

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -86,14 +86,21 @@ class SelendroidDriver extends BaseDriver {
       await this.checkAppPresent();
       this.opts.systemPort = this.opts.selendroidPort || SYSTEM_PORT_RANGE[0];
       this.opts.adbPort = this.opts.adbPort || DEFAULT_ADB_PORT;
-      if (this.opts.reboot) {
-        this.setAvdFromCapabilities(caps);
-      }
       await this.startSelendroidSession();
       return [sessionId, caps];
     } catch (e) {
       await this.deleteSession();
       throw e;
+    }
+  }
+
+  validateDesiredCaps (caps) {
+    // check with the base class, and return if it fails
+    let res = super.validateDesiredCaps(caps);
+    if (!res) return res;
+
+    if (this.opts.reboot) {
+      this.setAvdFromCapabilities(caps);
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -86,11 +86,29 @@ class SelendroidDriver extends BaseDriver {
       await this.checkAppPresent();
       this.opts.systemPort = this.opts.selendroidPort || SYSTEM_PORT_RANGE[0];
       this.opts.adbPort = this.opts.adbPort || DEFAULT_ADB_PORT;
+      if (this.opts.reboot) {
+        this.setAvdFromCapabilities(caps);
+      }
       await this.startSelendroidSession();
       return [sessionId, caps];
     } catch (e) {
       await this.deleteSession();
       throw e;
+    }
+  }
+
+  setAvdFromCapabilities (caps) {
+    if (this.opts.avd) {
+      logger.info('avd name defined, ignoring device name and platform version');
+    } else {
+      if (!caps.deviceName) {
+        logger.errorAndThrow('avd or deviceName should be specified when reboot option is enables');
+      }
+      if (!caps.platformVersion) {
+        logger.errorAndThrow('avd or platformVersion should be specified when reboot option is enabled');
+      }
+      let avdDevice = caps.deviceName.replace(/[^a-zA-Z0-9_.]/g, "-");
+      this.opts.avd = `${avdDevice}__${caps.platformVersion}`;
     }
   }
 
@@ -232,6 +250,11 @@ class SelendroidDriver extends BaseDriver {
       }
       await this.adb.forceStop(this.opts.appPackage);
       await this.adb.stopLogcat();
+      if (this.opts.reboot) {
+        let avdName = this.opts.avd.replace('@', '');
+        logger.debug(`closing emulator '${avdName}'`);
+        await this.adb.killEmulator(avdName);
+      }
     }
     await super.deleteSession();
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -109,7 +109,7 @@ class SelendroidDriver extends BaseDriver {
       logger.info('avd name defined, ignoring device name and platform version');
     } else {
       if (!caps.deviceName) {
-        logger.errorAndThrow('avd or deviceName should be specified when reboot option is enables');
+        logger.errorAndThrow('avd or deviceName should be specified when reboot option is enabled');
       }
       if (!caps.platformVersion) {
         logger.errorAndThrow('avd or platformVersion should be specified when reboot option is enabled');


### PR DESCRIPTION
The below document says if `reboot` option is true, reboot emulator after each session and kill it at the end.
https://github.com/appium/appium/blob/v1.6.3/docs/en/writing-running-appium/server-args.md

But actually it works only when using appium-android-driver.
So I implemented the reboot option with reference to the implementation of appium-android-driver.