### PR TITLE
Update params for appium-android-driver unlock

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -155,7 +155,7 @@ class SelendroidDriver extends BaseDriver {
     // prepare our actual AUT, get it on the device, etc...
     await this.initAUT();
     // unlock the device to prepare it for testing
-    await helpers.unlock(this.adb);
+    await helpers.unlock(this, this.adb, this.caps);
     // launch selendroid and wait till its online and we have a session
     await this.selendroid.startSession(this.caps);
     // rescue selendroid if it fails to start our AUT

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "appium-adb": "^2.5.1",
-    "appium-android-driver": "^1.10.16",
+    "appium-android-driver": "^1.12.0",
     "appium-base-driver": "^2.0.1",
     "appium-support": "^2.5.0",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
Fix the call to the unlock method since we change it on appium-android-driver and it's failing to run test due to: 
```TypeError: Cannot read property 'isScreenLocked' of undefined```

We got this same issue for appium-uiautomator2-driver
[issue-7948](https://github.com/appium/appium/issues/7948#issuecomment-283030881)

and same fix for uiautomator2
[pr-66](https://github.com/appium/appium-uiautomator2-driver/pull/66)


Please review @jlipps @imurchie @whirosan 