### PR TITLE
Avoid 500 error while calling getRect method on selendroid element

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -63,6 +63,13 @@ commands.setValue = async function (value, elementId) {
   await this.selendroid.jwproxy.command(`/element/${elementId}/value`, 'POST', {value: [value]});
 };
 
+// This is needed to satisfy updated WebElement interface in Selenium 3
+commands.getElementRect = async function (elementId) {
+  const location = await this.selendroid.jwproxy.command(`/element/${elementId}/location`, 'GET');
+  const size = await this.selendroid.jwproxy.command(`/element/${elementId}/size`, 'GET');
+  return Object.assign(location, size);
+};
+
 // Need to override this for correct unicode support
 commands.keys = async function (value) {
   if (value instanceof Array) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -34,6 +34,7 @@ const NO_PROXY = [
   ['GET', new RegExp('^/session/[^/]+/context')],
   ['GET', new RegExp('^/session/[^/]+/contexts')],
   ['POST', new RegExp('^/session/[^/]+/element/[^/]+/value')],
+  ['GET', new RegExp('^/session/[^/]+/element/[^/]+/rect')],
   ['GET', new RegExp('^/session/[^/]+/network_connection')],
   ['POST', new RegExp('^/session/[^/]+/network_connection')],
   ['POST', new RegExp('^/session/[^/]+/ime')],


### PR DESCRIPTION
Unfortunately Selendroid module itself is not maintained, but we still have to use it. And it started to fail after upgrade to Selenium 3, since the module does not implement the newly added _getRect_ endpoint. This PR fixes the problem by patching the call inside selendroid driver and returning the correct response.